### PR TITLE
Remove the position:relative global declaration

### DIFF
--- a/assets/stylesheets/_defaults.sass
+++ b/assets/stylesheets/_defaults.sass
@@ -1,4 +1,3 @@
 =defaults
   *
-    position: relative
     box-sizing: border-box


### PR DESCRIPTION
Having `position: relative` set on every element is causing a few z-index related issues on Eagle, and I think it's also out of the scope of what Chameleon should offer, which is explicitly a layout library.
