### PR TITLE
Import all dependencies into individual files

### DIFF
--- a/assets/stylesheets/_core.sass
+++ b/assets/stylesheets/_core.sass
@@ -1,3 +1,2 @@
-@import "functions"
 @import "config"
 @import "mixins"

--- a/assets/stylesheets/_functions.sass
+++ b/assets/stylesheets/_functions.sass
@@ -1,2 +1,0 @@
-@import "functions/maps"
-@import "functions/units"

--- a/assets/stylesheets/helpers/_box.sass
+++ b/assets/stylesheets/helpers/_box.sass
@@ -1,3 +1,7 @@
+@import "../mixins/responsive"
+@import "../mixins/utility"
+@import "../config/sizing"
+
 $box-map: ('spaced': 'margin', 'padded': 'padding')
 $position-list: ('top' 'left' 'bottom' 'right')
 

--- a/assets/stylesheets/helpers/_position.sass
+++ b/assets/stylesheets/helpers/_position.sass
@@ -1,3 +1,5 @@
+@import "../mixins/responsive"
+
 +placeholders("aligned-left")
   text-align: left
 

--- a/assets/stylesheets/helpers/_visibility.sass
+++ b/assets/stylesheets/helpers/_visibility.sass
@@ -1,3 +1,5 @@
+@import "../mixins/responsive"
+
 // Hide from both screenreaders and browsers
 
 +placeholders("hidden")

--- a/assets/stylesheets/mixins/_responsive.sass
+++ b/assets/stylesheets/mixins/_responsive.sass
@@ -1,3 +1,5 @@
+@import "../config/breakpoints"
+
 =on($_device)
   @each $breakpoint in $device-breakpoints
     $device: nth($breakpoint, 1)

--- a/assets/stylesheets/objects/_grid.sass
+++ b/assets/stylesheets/objects/_grid.sass
@@ -1,3 +1,7 @@
+@import "../mixins/responsive"
+@import "../helpers/position"
+@import "../config/sizing"
+
 =grid-defaults($unmin: false, $spacing: -0.3em)
   .row
     @extend %expanded


### PR DESCRIPTION
As part of the Component rearchitecture to use CSS bundles, we are going to want to be able to import specific Chameleon files individually. Currently, it relies on a global scope to maintain access to variables & mixins across files. This PR declares any dependency in each file so we can include only the specific files we want/need when accessing Chameleon from a CSS module.